### PR TITLE
Update the SRID definition of the parquet raster standard

### DIFF
--- a/format-specs/parquet-raster.md
+++ b/format-specs/parquet-raster.md
@@ -101,12 +101,14 @@ The allowed URI schemes are:
 CRS is represented as a string value. Writer and reader implementations are
 responsible for serializing and deserializing the CRS, respectively.
 
-As a convention to maximize the interoperability, custom CRS values can be
-specified by a string of the format `type:value`, where `type` is one of
-the following values:
+To maximize interoperability, a CRS value SHOULD be specified using the format `authority_name:code`. This string (case-sensitive) must reference a CRS identifier from the [Spatial reference identifier](https://spatialreference.org/projjson_index.json) catalog.
 
-* `srid`: [Spatial reference identifier](https://spatialreference.org/projjson_index.json), `value` must be a valid code name from the EPSG authority.
-* `projjson`: [PROJJSON](https://proj.org/en/stable/specifications/projjson.html), `value` is the PROJJSON string.
+While a custom CRS can be specified using a full [PROJJSON](https://proj.org/en/stable/specifications/projjson.html)
+string stored in this field, this approach is DISCOURAGED for performance reasons.
+Instead, it is RECOMMENDED to use a well-known CRS identifier whenever possible.
+
+If no CRS value is provided, the default is [OGC:CRS84](https://www.opengis.net/def/crs/OGC/1.3/CRS84), which
+represents longitude, latitude coordinates based on the WGS84 datum.
 
 
 ## Metadata


### PR DESCRIPTION
As detailed in this issue https://github.com/opengeospatial/geoparquet/issues/262 , we now have the projjson definition live on https://spatialreference.org/projjson_index.json. I think it is a good idea to update the Parquet Raster section since we now have a long-live and open definition of SRID.

@cholmes @paleolimbot @migurski should we allow authorities other than EPSG? I saw there are ESRI, .. and so on listed here https://spatialreference.org/projjson_index.json . Some of the ids are more than integers.